### PR TITLE
Add MakeRequestRawAsync public method

### DIFF
--- a/DeviantartApi/Requester.cs
+++ b/DeviantartApi/Requester.cs
@@ -64,6 +64,23 @@ namespace DeviantartApi
             string minorVersion = "20160316", /*actual version on 2016-07-13*/
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            return Deserialize<T>(await MakeRequestRawAsync(url, content, method, minorVersion, cancellationToken));
+        }
+
+        public static Task<string> MakeRequestRawAsync(
+            Uri url,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return MakeRequestRawAsync(url, null, HttpMethod.Get, cancellationToken: cancellationToken);
+        }
+
+        private static async Task<string> MakeRequestRawAsync(
+            Uri url,
+            HttpContent content,
+            HttpMethod method,
+            string minorVersion = "20160316", /*actual version on 2016-07-13*/
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
 #if LOG_NETWORK
             int requestId = Interlocked.Increment(ref _requestId);
             Debug.WriteLine($"{requestId}. HTTP REQUEST [{method}]: {url}");
@@ -128,8 +145,7 @@ namespace DeviantartApi
 #if LOG_NETWORK
             Debug.WriteLine($"{requestId}. HTTP REQUEST RESPONSE: {reqResponse}");
 #endif
-            var response = Deserialize<T>(reqResponse);
-            return response;
+            return reqResponse;
         }
 
         private static HttpRequestMessage GetRequestMessage(Uri url, string minorVersion,


### PR DESCRIPTION
I wrote some code to scrape the list of my scraps from DeviantArt (since the API doesn't let you get at it) in an app that also used this library, and I was having some sort of deadlock problem I couldn't figure out. Having the library make the HTTP request fixed it, but it means I need to expose a method that doesn'ttry to deserialize JSON.

It would be nice if I could just fix the root problem, but I can't track it down.